### PR TITLE
Fix separator detection not working for one column csv files

### DIFF
--- a/lib/acsv/csv.rb
+++ b/lib/acsv/csv.rb
@@ -14,7 +14,10 @@ module ACSV
     #
     # @see http://www.ruby-doc.org/stdlib/libdoc/csv/rdoc/CSV.html#method-c-new
     def initialize(data, options = Hash.new)
-      options[:col_sep] ||= ACSV::Detect.separator(data)
+      if !options.key?(:col_sep) && (separator = ACSV::Detect.separator(data))
+        options[:col_sep] = separator
+      end
+
       super(data, options)
     end
 


### PR DESCRIPTION
Passing `col_sep: nil` option to CSV constructor causes CSV to separate each character as a separate column.

With CSV content as follows:

```
name
productboard
```

Parsed row before the fix (incorrect):

```
['p', 'r', 'o', 'd', 'u', 'c', 't', 'b', 'o', 'a', 'r', 'd', nil]
```

Parsed row after the fix (correct):

```
['productboard']
```